### PR TITLE
fix: switch back to explicit resource_type param

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ data "aws_arn" "this" {
 }
 
 resource "aws_s3_bucket_policy" "this" {
-  count  = data.aws_arn.this.service == "s3" ? 1 : 0
+  count  = var.resource_type == "aws_s3_bucket" ? 1 : 0
   bucket = data.aws_arn.this.resource
 
   policy = jsonencode({
@@ -21,7 +21,7 @@ resource "aws_s3_bucket_policy" "this" {
 }
 
 resource "aws_secretsmanager_secret_policy" "this" {
-  count      = data.aws_arn.this.service == "secretsmanager" ? 1 : 0
+  count      = var.resource_type == "aws_secretsmanager_secret" ? 1 : 0
   secret_arn = var.resource_arn
 
   policy = jsonencode({

--- a/vars.tf
+++ b/vars.tf
@@ -1,3 +1,13 @@
+variable "resource_type" {
+  description = "Type of resource to which the policy applies. Supports: 'aws_s3_bucket' or 'aws_secretsmanager_secret'"
+  type        = string
+
+  validation {
+    condition     = contains(["aws_s3_bucket", "aws_secretsmanager_secret"], var.resource_type)
+    error_message = "resource_type must be one of 'aws_s3_bucket' or 'aws_secretsmanager_secret'."
+  }
+}
+
 variable "resource_arn" {
   description = "The ARN of the resource to attach the policy to."
   type        = string


### PR DESCRIPTION
It seems that Terraform has an issue with planning when using the parsed ARN to determine the resource type, so go back to the explicit `resource_type` parameter instead.